### PR TITLE
Fix sample_av_hdmap_spec.json input video path

### DIFF
--- a/assets/sample_av_hdmap_spec.json
+++ b/assets/sample_av_hdmap_spec.json
@@ -1,6 +1,6 @@
 {
     "hdmap": {
         "control_weight": 1,
-        "input_control": "examples/sample_av_multi_control/input_hdmap.mp4"
+        "input_control": "assets/sample_av_multi_control_input_hdmap.mp4"
     }
 }


### PR DESCRIPTION
Fixes an incorrect input video file path for `sample_av_hdmap_spec.json`. This seems to be the only spec json file that has an outdated path.