### PR TITLE
Update README

### DIFF
--- a/examples/inference_cosmos_transfer1_7b.md
+++ b/examples/inference_cosmos_transfer1_7b.md
@@ -92,12 +92,15 @@ checkpoints/
 Here's an example command:
 
 ```bash
-export CUDA_VISIBLE_DEVICES=0
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir checkpoints \
     --input_video_path path/to/input_video.mp4 \
     --video_save_name output_video \
-    --controlnet_specs spec.json
+    --controlnet_specs spec.json \
+    --offload_guardrail_models \
+    --num_gpus $NUM_GPU
 ```
 
 Cosmos-Transfer1 supports a variety of configurations. You can pass your configuration in a JSON file via the argument `--controlnet_specs`. Let's go over a few examples:
@@ -107,13 +110,16 @@ Cosmos-Transfer1 supports a variety of configurations. You can pass your configu
 The following `controlnet_specs` only activates the edge controlnet.
 
 ```bash
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_edge \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_edge.json \
-    --offload_text_encoder_model
+    --offload_text_encoder_model \
+    --offload_guardrail_models \
+    --num_gpus $NUM_GPU
 ```
 
 You can also choose to run the inference on multiple GPUs as follows:
@@ -127,6 +133,7 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --n
     --video_save_folder outputs/example1_single_control_edge \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_edge.json \
     --offload_text_encoder_model \
+    --offload_guardrail_models \
     --num_gpus $NUM_GPU
 ```
 
@@ -159,15 +166,18 @@ You can use our prompt upsampler to convert your short prompt into a longer, mor
 
 
 ```bash
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0  cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_edge_upsampled_prompt \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_edge_short_prompt.json \
     --offload_text_encoder_model \
     --upsample_prompt \
-    --offload_prompt_upsampler
+    --offload_prompt_upsampler \
+    --offload_guardrail_models \
+    --num_gpus $NUM_GPU
 ```
 
 
@@ -187,13 +197,16 @@ Here is the generated video using the upsampled prompt.
 The following `controlnet_specs` activates vis, edge, depth, seg controls at the same time and apply uniform spatial weights.
 
 ```bash
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example2_uniform_weights \
     --controlnet_specs assets/inference_cosmos_transfer1_uniform_weights.json \
-    --offload_text_encoder_model
+    --offload_text_encoder_model \
+    --offload_guardrail_models \
+    --num_gpus $NUM_GPU
 ```
 
 This launches `transfer.py` and configures the controlnets for inference according to `assets/inference_cosmos_transfer1_uniform_weights.json`:
@@ -246,13 +259,16 @@ The output video can be found at `assets/example1_uniform_weights.mp4`.
 The following `controlnet_specs` activates vis, edge, depth, seg controls at the same time and apply spatiotemporal weights.
 
 ```bash
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example3_spatiotemporal_weights \
     --controlnet_specs assets/inference_cosmos_transfer1_spatiotemporal_weights_auto.json \
-    --offload_text_encoder_model
+    --offload_text_encoder_model \
+    --offload_guardrail_models \
+    --num_gpus $NUM_GPU
 ```
 
 This launches `transfer.py` and configures the controlnets for inference according to `assets/inference_cosmos_transfer1_spatiotemporal_weights_auto.json`:
@@ -308,13 +324,16 @@ Each line in the JSONL file must contain a `visual_input` field equivalent to th
 ```
 Inference command (with 9 input frames):
 ```bash
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example2_uniform_weights \
     --controlnet_specs assets/inference_cosmos_transfer1_uniform_weights.json \
-    --offload_text_encoder_model  --batch_input_path path/to/batch_input_path.json
+    --offload_text_encoder_model \
+    --batch_input_path path/to/batch_input_path.json \
+    --num_gpus $NUM_GPU
 ```
 
 

--- a/examples/inference_cosmos_transfer1_7b_4kupscaler.md
+++ b/examples/inference_cosmos_transfer1_7b_4kupscaler.md
@@ -79,14 +79,16 @@ For a general overview of how to use the model see [this guide](/examples/infere
 Ensure you are at the root of the repository before executing the following:
 
 ```bash
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/inference_upscaler \
     --controlnet_specs assets/inference_upscaler.json \
     --num_steps 10 \
-    --offload_text_encoder_model
+    --offload_text_encoder_model \
+    --num_gpus $NUM_GPU
 ```
 
 You can also choose to run the inference on multiple GPUs as follows:

--- a/examples/inference_cosmos_transfer1_7b_sample_av.md
+++ b/examples/inference_cosmos_transfer1_7b_sample_av.md
@@ -82,16 +82,18 @@ Ensure you are at the root of the repository before executing the following:
 ```bash
 #!/bin/bash
 export PROMPT="The video is captured from a camera mounted on a car. The camera is facing forward. The video showcases a scenic golden-hour drive through a suburban area, bathed in the warm, golden hues of the setting sun. The dashboard camera captures the play of light and shadow as the sun’s rays filter through the trees, casting elongated patterns onto the road. The streetlights remain off, as the golden glow of the late afternoon sun provides ample illumination. The two-lane road appears to shimmer under the soft light, while the concrete barrier on the left side of the road reflects subtle warm tones. The stone wall on the right, adorned with lush greenery, stands out vibrantly under the golden light, with the palm trees swaying gently in the evening breeze. Several parked vehicles, including white sedans and vans, are seen on the left side of the road, their surfaces reflecting the amber hues of the sunset. The trees, now highlighted in a golden halo, cast intricate shadows onto the pavement. Further ahead, houses with red-tiled roofs glow warmly in the fading light, standing out against the sky, which transitions from deep orange to soft pastel blue. As the vehicle continues, a white sedan is seen driving in the same lane, while a black sedan and a white van move further ahead. The road markings are crisp, and the entire setting radiates a peaceful, almost cinematic beauty. The golden light, combined with the quiet suburban landscape, creates an atmosphere of tranquility and warmth, making for a mesmerizing and soothing drive."
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_name output_video \
     --video_save_folder outputs/sample_av_multi_control \
     --prompt "$PROMPT" \
     --sigma_max 80 \
     --offload_text_encoder_model --is_av_sample \
-    --controlnet_specs assets/sample_av_multi_control_spec.json
+    --controlnet_specs assets/sample_av_multi_control_spec.json \
+    --num_gpus $NUM_GPU
 ```
 
 You can also choose to run the inference on multiple GPUs as follows:
@@ -162,13 +164,15 @@ Feel free to experiment with more specs. For example, the command below only use
 
 ```bash
 export PROMPT="The video is captured from a camera mounted on a car. The camera is facing forward. The video showcases a scenic golden-hour drive through a suburban area, bathed in the warm, golden hues of the setting sun. The dashboard camera captures the play of light and shadow as the sun’s rays filter through the trees, casting elongated patterns onto the road. The streetlights remain off, as the golden glow of the late afternoon sun provides ample illumination. The two-lane road appears to shimmer under the soft light, while the concrete barrier on the left side of the road reflects subtle warm tones. The stone wall on the right, adorned with lush greenery, stands out vibrantly under the golden light, with the palm trees swaying gently in the evening breeze. Several parked vehicles, including white sedans and vans, are seen on the left side of the road, their surfaces reflecting the amber hues of the sunset. The trees, now highlighted in a golden halo, cast intricate shadows onto the pavement. Further ahead, houses with red-tiled roofs glow warmly in the fading light, standing out against the sky, which transitions from deep orange to soft pastel blue. As the vehicle continues, a white sedan is seen driving in the same lane, while a black sedan and a white van move further ahead. The road markings are crisp, and the entire setting radiates a peaceful, almost cinematic beauty. The golden light, combined with the quiet suburban landscape, creates an atmosphere of tranquility and warmth, making for a mesmerizing and soothing drive."
-export CUDA_VISIBLE_DEVICES=0
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+export NUM_GPU="${NUM_GPU:=1}"
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_name output_video \
     --video_save_folder outputs/sample_av_hdmap_spec \
     --prompt "$PROMPT" \
     --offload_text_encoder_model --is_av_sample \
-    --controlnet_specs assets/sample_av_hdmap_spec.json
+    --controlnet_specs assets/sample_av_hdmap_spec.json \
+    --num_gpus $NUM_GPU
 ```


### PR DESCRIPTION
Update README (inference_cosmos_transfer1_7b, inference_cosmos_transfer1_7b, inference_cosmos_transfer1_7b_4kupscaler)
1.  Substitute `python` with `torchrun` in all examples for consistency (solve the issue of missing prompt upsampler in single-GPU use`python`)
3. Add `--offload_guardrail_models` to save GPU memory
