### PR TITLE
Remove CUDA_HOME=$CONDA_PREFIX from all markdowns

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ pip install transformer-engine[pytorch]
 
 To test the environment setup for inference run
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/test_environment.py
+PYTHONPATH=$(pwd) python scripts/test_environment.py
 ```
 
 ### Inference using docker
@@ -79,10 +79,10 @@ ln -sf $CONDA_PREFIX/lib/python3.12/site-packages/nvidia/*/include/* $CONDA_PREF
 pip install transformer-engine[pytorch]
 # Install Apex for full training with bfloat16.
 git clone https://github.com/NVIDIA/apex
-CUDA_HOME=$CONDA_PREFIX pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./apex
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./apex
 ```
 
 You can test the environment setup for post-training with
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/test_environment.py --training
+PYTHONPATH=$(pwd) python scripts/test_environment.py --training
 ```

--- a/cosmos_transfer1/auxiliary/robot_augmentation/README.md
+++ b/cosmos_transfer1/auxiliary/robot_augmentation/README.md
@@ -85,7 +85,7 @@ export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
 
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 \
 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/robot_example_spatial_temporal_setting1 \

--- a/examples/inference_cosmos_transfer1_7b.md
+++ b/examples/inference_cosmos_transfer1_7b.md
@@ -21,7 +21,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e):
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
 ```
 
 Note that this will require about 300GB of free storage. Not all these checkpoints will be used in every generation.
@@ -88,7 +88,7 @@ Here's an example command:
 ```bash
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir checkpoints \
     --input_video_path path/to/input_video.mp4 \
     --video_save_name output_video \
@@ -107,7 +107,7 @@ The following `controlnet_specs` only activates the edge controlnet.
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_edge \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_edge.json \
@@ -122,7 +122,7 @@ You can also choose to run the inference on multiple GPUs as follows:
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0,1,2,3}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=4}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_edge \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_edge.json \
@@ -162,7 +162,7 @@ You can use our prompt upsampler to convert your short prompt into a longer, mor
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0  cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0  cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_edge_upsampled_prompt \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_edge_short_prompt.json \
@@ -192,7 +192,7 @@ The following `controlnet_specs` activates vis, edge, depth, seg controls at the
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example2_uniform_weights \
     --controlnet_specs assets/inference_cosmos_transfer1_uniform_weights.json \
@@ -254,7 +254,7 @@ The following `controlnet_specs` activates vis, edge, depth, seg controls at the
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example3_spatiotemporal_weights \
     --controlnet_specs assets/inference_cosmos_transfer1_spatiotemporal_weights_auto.json \
@@ -321,7 +321,7 @@ Inference command (with 9 input frames):
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example2_uniform_weights \
     --controlnet_specs assets/inference_cosmos_transfer1_uniform_weights.json \

--- a/examples/inference_cosmos_transfer1_7b_4kupscaler.md
+++ b/examples/inference_cosmos_transfer1_7b_4kupscaler.md
@@ -21,7 +21,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e):
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
 ```
 
 Note that this will require about 300GB of free storage. Not all these checkpoints will be used in every generation.
@@ -76,7 +76,7 @@ Ensure you are at the root of the repository before executing the following:
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/inference_upscaler \
     --controlnet_specs assets/inference_upscaler.json \
@@ -91,7 +91,7 @@ You can also choose to run the inference on multiple GPUs as follows:
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0,1,2,3}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=4}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/inference_upscaler \
     --controlnet_specs assets/inference_upscaler.json \

--- a/examples/inference_cosmos_transfer1_7b_depth.md
+++ b/examples/inference_cosmos_transfer1_7b_depth.md
@@ -5,7 +5,7 @@ Here is another simple example of using the Depth control. Many steps are simila
 ```bash
 export CUDA_VISIBLE_DEVICES=0
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_depth \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_depth.json \

--- a/examples/inference_cosmos_transfer1_7b_regionwise_prompt.md
+++ b/examples/inference_cosmos_transfer1_7b_regionwise_prompt.md
@@ -5,7 +5,7 @@ Here is another simple example of using multi control with regionwise prompts. M
 ```bash
 export CUDA_VISIBLE_DEVICES=0
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
     --video_save_folder outputs/example1_multi_control_regional_prompt_video_mask \
     --controlnet_specs assets/regionalprompt_test/inference_cosmos_transfer1_multi_control_regional_prompt_video_mask.json \
     --offload_text_encoder_model --sigma_max 80 --offload_guardrail_models

--- a/examples/inference_cosmos_transfer1_7b_sample_av.md
+++ b/examples/inference_cosmos_transfer1_7b_sample_av.md
@@ -21,7 +21,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e):
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
 ```
 
 Note that this will require about 300GB of free storage. Not all these checkpoints will be used in every generation.
@@ -79,7 +79,7 @@ export PROMPT="The video is captured from a camera mounted on a car. The camera 
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_name output_video \
     --video_save_folder outputs/sample_av_multi_control \
@@ -96,7 +96,7 @@ You can also choose to run the inference on multiple GPUs as follows:
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0,1,2,3}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=4}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_name output_video \
     --video_save_folder outputs/sample_av_multi_control \
@@ -161,7 +161,7 @@ export PROMPT="The video is captured from a camera mounted on a car. The camera 
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_name output_video \
     --video_save_folder outputs/sample_av_hdmap_spec \

--- a/examples/inference_cosmos_transfer1_7b_sample_av_single2multiview.md
+++ b/examples/inference_cosmos_transfer1_7b_sample_av_single2multiview.md
@@ -21,7 +21,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e):
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/ --model 7b_av
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/ --model 7b_av
 ```
 
 Note that this will require about 300GB of free storage. Not all these checkpoints will be used in every generation.
@@ -87,7 +87,7 @@ export PROMPT="The video is captured from a camera mounted on a car. The camera 
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPUS=1
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=${NUM_GPUS} cosmos_transfer1/diffusion/inference/transfer_multiview.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=${NUM_GPUS} cosmos_transfer1/diffusion/inference/transfer_multiview.py \
 --checkpoint_dir $CHECKPOINT_DIR \
 --video_save_name output_video_1_30_0 \
 --video_save_folder outputs/sample_av_multiview \
@@ -106,7 +106,7 @@ export PROMPT="The video is captured from a camera mounted on a car. The camera 
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPUS=1
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=${NUM_GPUS} cosmos_transfer1/diffusion/inference/transfer_multiview.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=${NUM_GPUS} cosmos_transfer1/diffusion/inference/transfer_multiview.py \
 --checkpoint_dir $CHECKPOINT_DIR \
 --video_save_name output_video_extension \
 --video_save_folder outputs/sample_av_multiview \
@@ -135,7 +135,7 @@ export PROMPT="The video is captured from a camera mounted on a car. The camera 
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPUS=1
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=${NUM_GPUS} cosmos_transfer1/diffusion/inference/transfer_multiview.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=${NUM_GPUS} cosmos_transfer1/diffusion/inference/transfer_multiview.py \
 --checkpoint_dir $CHECKPOINT_DIR \
 --video_save_name output_video \
 --video_save_folder outputs/sample_av_multiview_waymo \

--- a/examples/inference_cosmos_transfer1_7b_seg.md
+++ b/examples/inference_cosmos_transfer1_7b_seg.md
@@ -6,7 +6,7 @@ Here is another simple example of using the Segmentation control. Many steps are
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_seg \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_seg.json \

--- a/examples/inference_cosmos_transfer1_7b_vis.md
+++ b/examples/inference_cosmos_transfer1_7b_vis.md
@@ -6,7 +6,7 @@ Here is another simple example of using the Vis control. Many steps are similar 
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=1}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/example1_single_control_vis \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_vis.json \

--- a/examples/inference_cosmos_transfer1pt1_7b_keypoint.md
+++ b/examples/inference_cosmos_transfer1pt1_7b_keypoint.md
@@ -21,7 +21,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e):
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
 ```
 
 Note that this will require about 300GB of free storage. Not all these checkpoints will be used in every generation.
@@ -91,7 +91,7 @@ Ensure you are at the root of the repository before executing the following:
 ```bash
 export CUDA_VISIBLE_DEVICES=0
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) python cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/inference_keypoint \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_keypoint.json \
@@ -104,7 +104,7 @@ You can also choose to run the inference on multiple GPUs as follows:
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:=0,1,2,3}"
 export CHECKPOINT_DIR="${CHECKPOINT_DIR:=./checkpoints}"
 export NUM_GPU="${NUM_GPU:=4}"
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
+PYTHONPATH=$(pwd) torchrun --nproc_per_node=$NUM_GPU --nnodes=1 --node_rank=0 cosmos_transfer1/diffusion/inference/transfer.py \
     --checkpoint_dir $CHECKPOINT_DIR \
     --video_save_folder outputs/inference_keypoint \
     --controlnet_specs assets/inference_cosmos_transfer1_single_control_keypoint.json \

--- a/examples/training_cosmos_transfer_7B_sample_AV.md
+++ b/examples/training_cosmos_transfer_7B_sample_AV.md
@@ -39,7 +39,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e). Note that this will require about 300GB of free storage.
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
 ```
 
 5. The downloaded files should be in the following structure.

--- a/examples/training_cosmos_transfer_7b.md
+++ b/examples/training_cosmos_transfer_7b.md
@@ -38,7 +38,7 @@ huggingface-cli login
 4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-transfer1-67c9d328196453be6e568d3e). Note that this will require about 300GB of free storage.
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
+PYTHONPATH=$(pwd) python scripts/download_checkpoints.py --output_dir checkpoints/
 ```
 
 5. The downloaded files should be in the following structure.
@@ -148,7 +148,7 @@ pip install pytubefix ffmpeg
 
 ```bash
 # The script will downlaod the original HD-VILA-100M videos, save the corresponding clips, the captions and the metadata.
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_diffusion_example_data.py --dataset_path datasets/hdvila --N_videos 128 --do_download --do_clip
+PYTHONPATH=$(pwd) python scripts/download_diffusion_example_data.py --dataset_path datasets/hdvila --N_videos 128 --do_download --do_clip
 ```
 
 ### 2. Computing T5 Text Embeddings
@@ -156,7 +156,7 @@ Run the following command to pre-compute T5-XXL embeddings for the video caption
 
 ```bash
 # The script will read the captions, save the T5-XXL embeddings in pickle format.
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/get_t5_embeddings.py --dataset_path datasets/hdvila
+PYTHONPATH=$(pwd) python scripts/get_t5_embeddings.py --dataset_path datasets/hdvila
 ```
 
 ### 3. Obtaining the Control Input Data


### PR DESCRIPTION
Related to: [Issue#128](https://github.com/nvidia-cosmos/cosmos-transfer1/issues/128) 
Update all the markdown files to remove the CUDA_HOME=$CONDA_PREFIX from the command.

--- Files affected ---
**Examples:**
examples/inference_cosmos_transfer1_7b_depth.md
examples/training_cosmos_transfer_7B_sample_AV.md
examples/inference_cosmos_transfer1_7b_regionwise_prompt.md
examples/inference_cosmos_transfer1_7b_seg.md
examples/inference_cosmos_transfer1_7b_vis.md
examples/inference_cosmos_transfer1_7b_sample_av_single2multiview.md
examples/inference_cosmos_transfer1_7b_4kupscaler.md
examples/inference_cosmos_transfer1_7b_sample_av.md
examples/inference_cosmos_transfer1pt1_7b_keypoint.md
examples/inference_cosmos_transfer1_7b.md
examples/training_cosmos_transfer_7b.md

**Others:**
cosmos_transfer1/auxiliary/robot_augmentation/README.md
INSTALL.md


