### PR TITLE
Moved torch installation to script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,7 @@ export VLLM_ATTENTION_BACKEND=FLASHINFER
 pip install vllm==0.9.0
 # Install decord
 pip install decord==0.6.0
+pip install torch==2.7.0 torchvision==0.22.0 --ignore-installed --index-url https://download.pytorch.org/whl/cu128
 # Patch Transformer engine linking issues in conda environments.
 ln -sf $CONDA_PREFIX/lib/python3.12/site-packages/nvidia/*/include/* $CONDA_PREFIX/include/
 ln -sf $CONDA_PREFIX/lib/python3.12/site-packages/nvidia/*/include/* $CONDA_PREFIX/include/python3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,5 @@ retinaface_py==0.0.2
 rtmlib==0.0.13
 sam2==1.1.0
 termcolor==3.1.0
-torch==2.7.0 --index-url https://download.pytorch.org/whl/cu128
-torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 tqdm==4.67.1
 transformers==4.49.0


### PR DESCRIPTION
This PR updates the PyTorch installation instruction, as specifying the `--index-url` inside `requirements.txt` needs to be done top-level, which breaks other packages. We need to call the `pip install` directly, as is now specified in the instruction.