### PR TITLE
Add benchmark feature to transfer.py generation

### DIFF
--- a/cosmos_transfer1/diffusion/inference/transfer.py
+++ b/cosmos_transfer1/diffusion/inference/transfer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import argparse
 import copy
 import json
@@ -155,6 +156,11 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument("--use_distilled", action="store_true", help="Use distilled ControlNet model variant")
 
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
     cmd_args = parser.parse_args()
 
     # Load and parse JSON input
@@ -334,17 +340,32 @@ def demo(cfg, control_inputs):
             pipeline.region_definitions = region_definitions
 
         # Generate videos in batch
-        batch_outputs = pipeline.generate(
-            prompt=batch_prompt_texts,
-            video_path=batch_video_paths,
-            negative_prompt=cfg.negative_prompt,
-            control_inputs=batch_control_inputs,
-            save_folder=video_save_subfolder,
-            batch_size=actual_batch_size,
-        )
-        if batch_outputs is None:
-            log.critical("Guardrail blocked generation for entire batch.")
-            continue
+        num_repeats = 4 if cfg.benchmark else 1
+        time_sum = 0
+        for i in range(num_repeats):
+            if cfg.benchmark and i > 0:
+                torch.cuda.synchronize()
+                start_time = time.time()
+            batch_outputs = pipeline.generate(
+                prompt=batch_prompt_texts,
+                video_path=batch_video_paths,
+                negative_prompt=cfg.negative_prompt,
+                control_inputs=batch_control_inputs,
+                save_folder=video_save_subfolder,
+                batch_size=actual_batch_size,
+            )
+            if cfg.benchmark and i > 0:
+                torch.cuda.synchronize()
+                elapsed = time.time() - start_time
+                time_sum += elapsed
+                log.info(f"[iter {i} / {num_repeats - 1}] Generation time: {elapsed:.1f} seconds.")
+            if batch_outputs is None:
+                log.critical("Guardrail blocked generation for entire batch.")
+                continue
+
+        if cfg.benchmark:
+            time_avg = time_sum / (num_repeats - 1)
+            log.critical(f"The benchmarked generation time for Cosmos-Transfer1 is {time_avg:.1f} seconds.")
 
         videos, final_prompts = batch_outputs
         for i, (video, prompt) in enumerate(zip(videos, final_prompts)):
@@ -355,6 +376,7 @@ def demo(cfg, control_inputs):
             else:
                 video_save_path = os.path.join(cfg.video_save_folder, f"{cfg.video_save_name}.mp4")
                 prompt_save_path = os.path.join(cfg.video_save_folder, f"{cfg.video_save_name}.txt")
+
             # Save video and prompt
             if device_rank == 0:
                 os.makedirs(os.path.dirname(video_save_path), exist_ok=True)


### PR DESCRIPTION
Adds a benchmark flag to transfer.py to accurately measure generation time without any overhead.