### PR TITLE
Startup script for gradio app

### DIFF
--- a/server/start_gradio_app.sh
+++ b/server/start_gradio_app.sh
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 # Start script for the gradio app:
+# - Verifies that CHECKPOINT_DIR and GRADIO_APP exist
 # - Creates directories specified by environment variables
 # - Installs gradio
 # - Starts the app, teeing output to the log file
@@ -28,6 +29,21 @@ export CHECKPOINT_DIR=${CHECKPOINT_DIR:-$REPO_ROOT/checkpoints}
 export OUTPUT_DIR=${OUTPUT_DIR:-$REPO_ROOT/outputs/gradio/output}
 export UPLOADS_DIR=${UPLOADS_DIR:-$REPO_ROOT/outputs/gradio/uploads}
 export LOG_FILE=${LOG_FILE:-$REPO_ROOT/outputs/gradio/logs/$(date +%Y%m%d_%H%M%S).txt}
+export GRADIO_APP=${GRADIO_APP:-$REPO_ROOT/server/gradio_app.py}
+
+# Verify that checkpoints directory exists
+echo "Checking if checkpoints directory exists: $CHECKPOINT_DIR"
+if [ ! -d "$CHECKPOINT_DIR" ]; then
+    echo "Error: Checkpoints directory does not exist: $CHECKPOINT_DIR"
+    exit 1
+fi
+
+# Verify that gradio app exists
+echo "Checking if gradio app exists: $GRADIO_APP"
+if [ ! -f "$GRADIO_APP" ]; then
+    echo "Error: Gradio app does not exist: $GRADIO_APP"
+    exit 1
+fi
 
 # Create output directories
 echo "Creating application directories..."
@@ -55,6 +71,6 @@ for dependency in "${dependencies[@]}"; do
 done
 
 # Start the app and tee output to the log file
-command="cd $REPO_ROOT && PYTHONPATH=. python3 server/gradio_app.py 2>&1 | tee -a $LOG_FILE"
+command="cd $REPO_ROOT && PYTHONPATH=. python3 $GRADIO_APP 2>&1 | tee -a $LOG_FILE"
 echo "Starting the app: $command"
 eval $command

--- a/server/start_gradio_app.sh
+++ b/server/start_gradio_app.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start script for the gradio app:
+# - Creates directories specified by environment variables
+# - Installs gradio
+# - Starts the app, teeing output to the log file
+
+# Get the repo root (expected to be called from within the repo)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Export environment variables if not already set
+export CHECKPOINT_DIR=${CHECKPOINT_DIR:-$REPO_ROOT/checkpoints}
+export OUTPUT_DIR=${OUTPUT_DIR:-$REPO_ROOT/outputs/gradio/output}
+export UPLOADS_DIR=${UPLOADS_DIR:-$REPO_ROOT/outputs/gradio/uploads}
+export LOG_FILE=${LOG_FILE:-$REPO_ROOT/outputs/gradio/logs/$(date +%Y%m%d_%H%M%S).txt}
+
+# Create output directories
+echo "Creating application directories..."
+directories=($CHECKPOINT_DIR $OUTPUT_DIR $UPLOADS_DIR $(dirname $LOG_FILE))
+for dir in "${directories[@]}"; do
+    if [ -d "$dir" ]; then
+        echo "Directory already exists: $dir"
+    else
+        echo "Creating directory: $dir"
+        mkdir -p "$dir"
+    fi
+done
+
+# Install dependencies
+dependencies=("python-magic" "gradio")
+for dependency in "${dependencies[@]}"; do
+    echo "Checking if $dependency is installed..."
+    installed_version=$(python3 -m pip show $dependency 2>/dev/null | grep '^Version:')
+    if [ -n "$installed_version" ]; then
+        echo "$dependency is already installed: $installed_version"
+    else
+        echo "$dependency is not installed, installing..."
+        python3 -m pip install $dependency --break-system-packages
+    fi
+done
+
+# Start the app and tee output to the log file
+command="cd $REPO_ROOT && PYTHONPATH=. python3 server/gradio_app.py 2>&1 | tee -a $LOG_FILE"
+echo "Starting the app: $command"
+eval $command

--- a/server/start_gradio_app.sh
+++ b/server/start_gradio_app.sh
@@ -42,7 +42,7 @@ for dir in "${directories[@]}"; do
 done
 
 # Install dependencies
-dependencies=("python-magic" "gradio")
+dependencies=("gradio")
 for dependency in "${dependencies[@]}"; do
     echo "Checking if $dependency is installed..."
     installed_version=$(python3 -m pip show $dependency 2>/dev/null | grep '^Version:')


### PR DESCRIPTION
### Summary
Adds a startup script for the gradio app introduced in #168 .
- Creates output directories referenced in environment variables to avoid issues if those directories don't exist
- Creates a datetime-unique logfile
- Installs dependencies not included in the Dockerfile (`python-magic` and `gradio`)
- Prints the command used to start the application (useful for the user)
- Starts the app and `tee`'s output to the logfile

This script can be used for automated deployments of the gradio app.

### Testing
<details><summary>Sample output when directories do NOT exist and dependencies are NOT installed</summary>

```bash
root@nhr-workspace-0-0:/mnt/pvc/code/github/nhayesroth-cosmos-transfer1# CHECKPOINT_DIR=/mnt/pvc/code/github/cosmos-transfer1/checkpoints/ ./server/start_gradio_app.sh 
Creating application directories...
Directory already exists: /mnt/pvc/code/github/cosmos-transfer1/checkpoints/
Creating directory: /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/output
Creating directory: /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/uploads
Creating directory: /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/logs
Checking if python-magic is installed...
python-magic is not installed, installing...
Collecting python-magic
  Using cached python_magic-0.4.27-py2.py3-none-any.whl.metadata (5.8 kB)
Using cached python_magic-0.4.27-py2.py3-none-any.whl (13 kB)
Installing collected packages: python-magic
Successfully installed python-magic-0.4.27
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Checking if gradio is installed...
gradio is not installed, installing...
Collecting gradio
  Using cached gradio-5.39.0-py3-none-any.whl.metadata (16 kB)
Requirement already satisfied: aiofiles<25.0,>=22.0 in /usr/local/lib/python3.12/dist-packages (from gradio) (24.1.0)
Requirement already satisfied: ...
...
Using cached gradio-5.39.0-py3-none-any.whl (59.5 MB)
Installing collected packages: gradio
Successfully installed gradio-5.39.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Starting the app: cd /mnt/pvc/code/github/nhayesroth-cosmos-transfer1 && PYTHONPATH=. python3 server/gradio_app.py 2>&1 | tee -a /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/logs/20250804_185814.txt
INFO 08-04 18:58:44 [__init__.py:256] Automatically detected platform cuda.
...
```

</details>

<details><summary>Sample output when directories exist and dependencies are installed</summary>

```bash
root@nhr-workspace-0-0:/mnt/pvc/code/github/nhayesroth-cosmos-transfer1# CHECKPOINT_DIR=/mnt/pvc/code/github/cosmos-transfer1/checkpoints/ ./server/start_gradio_app.sh 
Creating application directories...
Directory already exists: /mnt/pvc/code/github/cosmos-transfer1/checkpoints/
Directory already exists: /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/output
Directory already exists: /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/uploads
Directory already exists: /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/logs
Checking if python-magic is installed...
python-magic is already installed: Version: 0.4.27
Checking if gradio is installed...
gradio is already installed: Version: 5.39.0
Starting the app: cd /mnt/pvc/code/github/nhayesroth-cosmos-transfer1 && PYTHONPATH=. python3 server/gradio_app.py 2>&1 | tee -a /mnt/pvc/code/github/nhayesroth-cosmos-transfer1/outputs/gradio/logs/20250804_190723.txt
...
```

</details>