### PR TITLE
Fix(install.md): Update install instructions.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,8 +28,6 @@ export VLLM_ATTENTION_BACKEND=FLASHINFER
 pip install vllm==0.9.0
 pip install transformers==4.51.1
 
-# Install decord
-pip install decord==0.6.0
 pip install torch==2.7.0 torchvision==0.22.0 --ignore-installed --index-url https://download.pytorch.org/whl/cu128
 # Patch Transformer engine linking issues in conda environments.
 ln -sf $CONDA_PREFIX/lib/python3.12/site-packages/nvidia/*/include/* $CONDA_PREFIX/include/


### PR DESCRIPTION
The latest version of the `transformers` module installed by the `vllm==0.9.0` module causes issues with vllm 0.9.0.
Adding line to downgrade transformers to avoid this [issue](https://github.com/vllm-project/vllm-ascend/issues/2046) in vllm.

Pin `transformer-engine[pytorch]` to `2.5.0`. Yesterday, my environment began installing `2.6.0`, which unfortunately seems to have compatibility issues as it was looking for `libcublas.so.13`, despite supporting CUDA 12.1+ on Hopper architecture.

<img width="943" height="283" alt="image" src="https://github.com/user-attachments/assets/212b605a-4d14-46fb-9623-70831873e987" />


Tested on:
System Architecture: x86_64-Linux
Hardware: 8x NVIDIA H100 80GB SXM5 (Mithril.ai Instance)
System: Ubuntu24.04 2025.08.01
Conda: 25.5.1
Nvidia Driver: 570.86.10
CUDA Version: 12.8 