### PR TITLE
feat: enable option to save noise for Knowledge Distillation

### DIFF
--- a/cosmos_transfer1/diffusion/inference/inference_utils.py
+++ b/cosmos_transfer1/diffusion/inference/inference_utils.py
@@ -708,7 +708,8 @@ def generate_world_from_control(
     x_sigma_max=None,
     augment_sigma=None,
     use_batch_processing: bool = True,
-) -> Tuple[np.array, list, list]:
+    save_input_noise: bool = False,
+) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor]:
     """Generate video using a conditioning video/image input.
 
     Args:
@@ -721,9 +722,10 @@ def generate_world_from_control(
         seed (int): Random seed for generation
         condition_latent (torch.Tensor): Latent tensor from conditioning video/image file
         num_input_frames (int): Number of input frames
+        save_input_noise (bool): Whether to save input noise
 
     Returns:
-        np.array: Generated video frames in shape [T,H,W,C], range [0,255]
+        Generated video frames tensor or tuple of (video frames tensor, input noise tensor)
     """
     assert not model.config.conditioner.video_cond_bool.sample_tokens_start_from_p_or_i, "not supported"
 
@@ -759,6 +761,7 @@ def generate_world_from_control(
         patch_h=h,
         patch_w=w,
         use_batch_processing=use_batch_processing,
+        save_input_noise=save_input_noise,
     )
     return sample
 

--- a/cosmos_transfer1/diffusion/inference/transfer.py
+++ b/cosmos_transfer1/diffusion/inference/transfer.py
@@ -23,6 +23,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Workaround to suppress MP warn
 
 import sys
 from io import BytesIO
+import pickle
 
 import torch
 
@@ -38,6 +39,7 @@ from cosmos_transfer1.diffusion.inference.world_generation_pipeline import (
     DistilledControl2WorldGenerationPipeline,
 )
 from cosmos_transfer1.utils import log, misc
+from cosmos_transfer1.utils.easy_io import easy_io
 from cosmos_transfer1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -155,6 +157,11 @@ def parse_arguments() -> argparse.Namespace:
         help="Offload prompt upsampler model after inference",
     )
     parser.add_argument("--use_distilled", action="store_true", help="Use distilled ControlNet model variant")
+    parser.add_argument(
+        "--save_input_noise",
+        action="store_true",
+        help="Save input noise for ODE pairs generation used for Knowledge Distillation",
+    )
 
     parser.add_argument(
         "--benchmark",
@@ -224,6 +231,7 @@ def demo(cfg, control_inputs):
 
     if cfg.use_distilled:
         assert not cfg.is_av_sample
+        assert not cfg.save_input_noise, "Saving input noise is not supported for distilled models"
         checkpoint = EDGE2WORLD_CONTROLNET_7B_DISTILLED_CHECKPOINT_PATH
         pipeline = DistilledControl2WorldGenerationPipeline(
             checkpoint_dir=cfg.checkpoint_dir,
@@ -266,6 +274,7 @@ def demo(cfg, control_inputs):
             upsample_prompt=cfg.upsample_prompt,
             offload_prompt_upsampler=cfg.offload_prompt_upsampler,
             process_group=process_group,
+            save_input_noise=cfg.save_input_noise,
         )
 
     if cfg.batch_input_path:
@@ -369,15 +378,22 @@ def demo(cfg, control_inputs):
             time_avg = time_sum / (num_repeats - 1)
             log.critical(f"The benchmarked generation time for Cosmos-Transfer1 is {time_avg:.1f} seconds.")
 
-        videos, final_prompts = batch_outputs
-        for i, (video, prompt) in enumerate(zip(videos, final_prompts)):
+        if cfg.save_input_noise:
+            videos, final_prompts, input_noise = batch_outputs
+        else:
+            videos, final_prompts = batch_outputs
+            input_noise = [None] * len(videos)
+
+        for i, (video, prompt, noise) in enumerate(zip(videos, final_prompts, input_noise)):
             if cfg.batch_input_path:
                 video_save_subfolder = os.path.join(cfg.video_save_folder, f"video_{batch_start+i}")
                 video_save_path = os.path.join(video_save_subfolder, "output.mp4")
                 prompt_save_path = os.path.join(video_save_subfolder, "prompt.txt")
+                noise_save_path = os.path.join(video_save_subfolder, "noise.pickle")
             else:
                 video_save_path = os.path.join(cfg.video_save_folder, f"{cfg.video_save_name}.mp4")
                 prompt_save_path = os.path.join(cfg.video_save_folder, f"{cfg.video_save_name}.txt")
+                noise_save_path = os.path.join(cfg.video_save_folder, "noise.pickle")
 
             # Save video and prompt
             if device_rank == 0:
@@ -390,13 +406,16 @@ def demo(cfg, control_inputs):
                     video_save_quality=5,
                     video_save_path=video_save_path,
                 )
+                log.info(f"Saved video to {video_save_path}")
 
                 # Save prompt to text file alongside video
                 with open(prompt_save_path, "wb") as f:
                     f.write(prompt.encode("utf-8"))
-
-                log.info(f"Saved video to {video_save_path}")
                 log.info(f"Saved prompt to {prompt_save_path}")
+
+                if cfg.save_input_noise:
+                    easy_io.dump(noise, noise_save_path)
+                    log.info(f"Saved input noise to {noise_save_path}")
 
     # clean up properly
     if cfg.num_gpus > 1:

--- a/cosmos_transfer1/diffusion/inference/transfer.py
+++ b/cosmos_transfer1/diffusion/inference/transfer.py
@@ -21,9 +21,9 @@ import time
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Workaround to suppress MP warning
 
+import pickle
 import sys
 from io import BytesIO
-import pickle
 
 import torch
 

--- a/cosmos_transfer1/diffusion/inference/world_generation_pipeline.py
+++ b/cosmos_transfer1/diffusion/inference/world_generation_pipeline.py
@@ -146,6 +146,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         region_definitions: Union[List[List[float]], torch.Tensor] = None,
         waymo_example: bool = False,
         disable_guardrail: bool = False,
+        save_input_noise: bool = False,
     ):
         """Initialize diffusion world generation pipeline.
 
@@ -174,6 +175,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
             process_group: Process group for distributed training
             waymo_example: Whether to use the waymo example post-training checkpoint
             disable_guardrail: Whether to disable guardrail checks
+            save_input_noise: Whether to save input noise for ODE pairs generation used for Knowledge Distillation
         """
         self.num_input_frames = num_input_frames
         self.control_inputs = control_inputs
@@ -197,6 +199,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         self.seed = seed
         self.regional_prompts = regional_prompts
         self.region_definitions = region_definitions
+        self.save_input_noise = save_input_noise
 
         super().__init__(
             checkpoint_dir=checkpoint_dir,
@@ -417,7 +420,8 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         video_paths: list[str],
         negative_prompt_embeddings: Optional[list[torch.Tensor]] = None,
         control_inputs_list: list[dict] = None,
-    ) -> list[np.ndarray]:
+        save_input_noise: bool = False,
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         """Generate world representation with automatic model offloading.
 
         Wraps the core generation process with model loading/offloading logic
@@ -428,6 +432,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
             video_paths: List of paths to input videos
             negative_prompt_embeddings: Optional list of embeddings for negative prompt guidance
             control_inputs_list: List of control input dictionaries
+            save_input_noise: Whether to save input noise
 
         Returns:
             list[np.ndarray]: List of generated world representations as numpy arrays
@@ -447,6 +452,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
             negative_prompt_embeddings=negative_prompt_embeddings,
             video_paths=video_paths,
             control_inputs_list=control_inputs_list,
+            save_input_noise=save_input_noise,
         )
 
         if self.offload_network:
@@ -463,7 +469,8 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         video_paths: list[str],  # [B]
         negative_prompt_embeddings: Optional[torch.Tensor] = None,  # [B, ...] or None
         control_inputs_list: list[dict] = None,  # [B] list of dicts
-    ) -> np.ndarray:
+        save_input_noise: bool = False,
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         """
         Batched world generation with model offloading.
         Each batch element corresponds to a (prompt, video, control_inputs) triple.
@@ -547,7 +554,9 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
 
         video = []
         prev_frames = None
+        input_noise = None
         for i_clip in tqdm(range(N_clip)):
+            log.error(f"i_clip: {i_clip}")
             # data_batch_i = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data_batch.items()}
             data_batch_i = {k: v for k, v in data_batch.items()}
             start_frame = num_new_generated_frames * i_clip
@@ -605,7 +614,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
 
             # Generate video frames for this clip (batched)
             log.info("Starting diffusion sampling")
-            latents = generate_world_from_control(
+            samples = generate_world_from_control(
                 model=self.model,
                 state_shape=state_shape,
                 is_negative_prompt=True,
@@ -618,7 +627,15 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
                 sigma_max=self.sigma_max if x_sigma_max is not None else None,
                 x_sigma_max=x_sigma_max,
                 use_batch_processing=False if is_upscale_case else True,
+                save_input_noise=save_input_noise,
             )
+            if self.save_input_noise:
+                latents, noise = samples
+                if i_clip == 0:
+                    input_noise = noise.to(torch.float32).cpu().numpy()
+            else:
+                latents = samples
+
             log.info("Completed diffusion sampling")
             log.info("Starting VAE decode")
             frames = self._run_tokenizer_decoding(
@@ -636,7 +653,10 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
 
         video = torch.cat(video, dim=2)[:, :, :T]
         video = video.permute(0, 2, 3, 4, 1).numpy()
-        return video
+        if self.save_input_noise:
+            return video, input_noise
+        else:
+            return video
 
     def generate(
         self,
@@ -646,7 +666,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         control_inputs: dict | list[dict] = None,
         save_folder: str = "outputs/",
         batch_size: int = 1,
-    ) -> tuple[np.ndarray, str | list[str]] | None:
+    ) -> tuple[np.ndarray, list[str], list[np.ndarray]] | tuple[np.ndarray, list[str]] | None:
         """Generate video from text prompt and control video.
 
         Pipeline steps:
@@ -666,6 +686,10 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         Returns:
             tuple: (
                 Generated video frames as uint8 np.ndarray [T, H, W, C],
+                Final prompt used for generation (may be enhanced),
+                Input noise as float32 np.ndarray
+            ), or tuple: (
+                Generated video frames as uint8 np.ndarray [T, H, W, C],
                 Final prompt used for generation (may be enhanced)
             ), or None if content fails guardrail safety checks
         """
@@ -684,6 +708,7 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         # Process prompts in batch
         all_videos = []
         all_final_prompts = []
+        all_input_noise = []
 
         # Upsample prompts if enabled
         if self.prompt_upsampler and int(os.environ["RANK"]) == 0:
@@ -748,12 +773,17 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
 
         all_neg_embeddings = [emb[1] for emb in all_prompt_embeddings]
         all_prompt_embeddings = [emb[0] for emb in all_prompt_embeddings]
-        videos = self._run_model_with_offload(
+        model_outputs = self._run_model_with_offload(
             prompt_embeddings=all_prompt_embeddings,
             negative_prompt_embeddings=all_neg_embeddings,
             video_paths=safe_video_paths,
             control_inputs_list=safe_control_inputs,
+            save_input_noise=self.save_input_noise,
         )
+        if self.save_input_noise:
+            videos, input_noise = model_outputs
+        else:
+            videos = model_outputs
         log.info("Finish generation")
 
         log.info("Run guardrail on generated videos")
@@ -762,12 +792,17 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
             if safe_video is not None:
                 all_videos.append(safe_video)
                 all_final_prompts.append(safe_prompts[i])
+                if self.save_input_noise:
+                    all_input_noise.append(input_noise[i])
             else:
                 log.critical(f"Generated video {i+1} is not safe")
         if not all_videos:
             log.critical("All generated videos failed safety checks")
             return None
-        return all_videos, all_final_prompts
+        if self.save_input_noise:
+            return all_videos, all_final_prompts, all_input_noise
+        else:
+            return all_videos, all_final_prompts
 
 
 class DiffusionControl2WorldMultiviewGenerationPipeline(DiffusionControl2WorldGenerationPipeline):
@@ -812,6 +847,7 @@ class DiffusionControl2WorldMultiviewGenerationPipeline(DiffusionControl2WorldGe
         view_condition_video="",
         initial_condition_video="",
         control_inputs: dict = None,
+        **kwargs,
     ) -> np.ndarray:
         """Generate world representation with automatic model offloading.
 
@@ -851,6 +887,7 @@ class DiffusionControl2WorldMultiviewGenerationPipeline(DiffusionControl2WorldGe
         view_condition_video="",
         initial_condition_video="",
         control_inputs: dict = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Generate video frames using the diffusion model.
 
@@ -1175,6 +1212,7 @@ class DiffusionControl2WorldMultiviewGenerationPipeline(DiffusionControl2WorldGe
         initial_condition_video: str,
         control_inputs: dict = None,
         save_folder: str = "outputs/",
+        **kwargs,
     ) -> tuple[np.ndarray, str] | None:
         """Generate video from text prompt and control video.
 
@@ -1284,6 +1322,7 @@ class DistilledControl2WorldGenerationPipeline(DiffusionControl2WorldGenerationP
         video_paths: list[str],  # [B]
         negative_prompt_embeddings: Optional[torch.Tensor] = None,  # [B, ...] or None
         control_inputs_list: list[dict] = None,  # [B] list of dicts
+        **kwargs,
     ) -> np.ndarray:
         """
         Batched world generation with model offloading.

--- a/cosmos_transfer1/diffusion/inference/world_generation_pipeline.py
+++ b/cosmos_transfer1/diffusion/inference/world_generation_pipeline.py
@@ -556,7 +556,6 @@ class DiffusionControl2WorldGenerationPipeline(BaseWorldGenerationPipeline):
         prev_frames = None
         input_noise = None
         for i_clip in tqdm(range(N_clip)):
-            log.error(f"i_clip: {i_clip}")
             # data_batch_i = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data_batch.items()}
             data_batch_i = {k: v for k, v in data_batch.items()}
             start_frame = num_new_generated_frames * i_clip

--- a/cosmos_transfer1/diffusion/training/models/model.py
+++ b/cosmos_transfer1/diffusion/training/models/model.py
@@ -18,7 +18,6 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import amp_C
 import torch
-from apex.multi_tensor_apply import multi_tensor_applier
 from einops import rearrange
 from megatron.core import parallel_state
 from torch import Tensor
@@ -26,6 +25,7 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from torch.distributed import broadcast_object_list, get_process_group_ranks
 from torch.distributed.utils import _verify_param_shape_across_processes
 
+from apex.multi_tensor_apply import multi_tensor_applier
 from cosmos_transfer1.diffusion.conditioner import BaseVideoCondition, DataType
 from cosmos_transfer1.diffusion.diffusion.modules.res_sampler import COMMON_SOLVER_OPTIONS
 from cosmos_transfer1.diffusion.module.parallel import cat_outputs_cp, split_inputs_cp

--- a/cosmos_transfer1/utils/fused_adam.py
+++ b/cosmos_transfer1/utils/fused_adam.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import torch
-from apex.multi_tensor_apply import multi_tensor_applier
 
+from apex.multi_tensor_apply import multi_tensor_applier
 from cosmos_transfer1.utils import distributed, log
 
 

--- a/examples/distillation_cosmos_transfer1_7b.md
+++ b/examples/distillation_cosmos_transfer1_7b.md
@@ -121,7 +121,7 @@ PYTHONPATH=$(pwd) python cosmos_transfer1/distillation/datasets/example_kd_datas
 
 #### 4. Generating Teacher Data and Saving Noise Input
 
-Follow the steps in the [inference README](./inference_cosmos_transfer1_7b.md) to generate output videos using the teacher model. You will need to modify the inference pipeline to additionally save the noise inputs used to generate the teacher data.
+Follow the steps in the [inference README](./inference_cosmos_transfer1_7b.md) to generate output videos using the teacher model. In order to configure the inference pipeline to additionally save the noise inputs used to generate the teacher data, pass the `--save_input_noise` flag.
 
 #### 5. Combining the Base and Control Checkpoints
 


### PR DESCRIPTION
For Knowledge Distillation, users need to generate synthetic data that includes the text input, control input, input noise, and teacher-generated output video.

This PR enables the option to save noise in the Cosmos-Transfer1 inference pipeline, which can be used for generating training data for Knowledge Distillation.