### PR TITLE
fix: video frame validation to enable automatic clipping in inference pipeline

### DIFF
--- a/cosmos_transfer1/diffusion/module/pretrained_vae.py
+++ b/cosmos_transfer1/diffusion/module/pretrained_vae.py
@@ -449,17 +449,19 @@ class BasePretrainedVideoTokenizer(ABC):
     def get_latent_num_frames(self, num_pixel_frames: int) -> int:
         if num_pixel_frames == 1:
             return 1
-        assert (
-            num_pixel_frames % self.pixel_chunk_duration == 0
-        ), f"Temporal dimension {num_pixel_frames} is not divisible by chunk_length {self.pixel_chunk_duration}"
+        if num_pixel_frames < self.pixel_chunk_duration:
+            raise ValueError(
+                f"Insufficient pixel frames: {num_pixel_frames} < minimum required {self.pixel_chunk_duration}"
+            )
         return num_pixel_frames // self.pixel_chunk_duration * self.latent_chunk_duration
 
     def get_pixel_num_frames(self, num_latent_frames: int) -> int:
         if num_latent_frames == 1:
             return 1
-        assert (
-            num_latent_frames % self.latent_chunk_duration == 0
-        ), f"Temporal dimension {num_latent_frames} is not divisible by chunk_length {self.latent_chunk_duration}"
+        if num_latent_frames < self.latent_chunk_duration:
+            raise ValueError(
+                f"Insufficient latent frames: {num_latent_frames} < minimum required {self.latent_chunk_duration}"
+            )
         return num_latent_frames // self.latent_chunk_duration * self.pixel_chunk_duration
 
 

--- a/cosmos_transfer1/diffusion/training/models/model.py
+++ b/cosmos_transfer1/diffusion/training/models/model.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import amp_C
 import torch
+from apex.multi_tensor_apply import multi_tensor_applier
 from einops import rearrange
 from megatron.core import parallel_state
 from torch import Tensor
@@ -25,7 +26,6 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from torch.distributed import broadcast_object_list, get_process_group_ranks
 from torch.distributed.utils import _verify_param_shape_across_processes
 
-from apex.multi_tensor_apply import multi_tensor_applier
 from cosmos_transfer1.diffusion.conditioner import BaseVideoCondition, DataType
 from cosmos_transfer1.diffusion.diffusion.modules.res_sampler import COMMON_SOLVER_OPTIONS
 from cosmos_transfer1.diffusion.module.parallel import cat_outputs_cp, split_inputs_cp

--- a/cosmos_transfer1/utils/fused_adam.py
+++ b/cosmos_transfer1/utils/fused_adam.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import torch
-
 from apex.multi_tensor_apply import multi_tensor_applier
+
 from cosmos_transfer1.utils import distributed, log
 
 


### PR DESCRIPTION
Issues:
1. The error message does not clearly mention that the input must have at least 121 frames.
2. Validation occurs too early in the pipeline, stopping videos from reaching the clipping logic that handles partial chunks. Currently, `get_pixel_num_frames` and `get_latent_num_frames` raise errors if the frame count isn't divisible by 121. This prevents inputs with more than 121 frames that aren't multiples of 121 from proceeding, even though autoclipping logic exists further down the pipeline before tensor reshaping.

Fix: 
Since validation is already enforced in `transform_encode_state_shape` (lines 366-368) where tensor reshaping happens, we can relax these asserts to only check for inputs that don't meet the minimum frame requirement. The error message is updated to clearly indicate the issue.