### PR TITLE
fix: wrong checkpoints path for DepthAnythingModel when input control is null

### DIFF
--- a/cosmos_transfer1/auxiliary/depth_anything/model/depth_anything.py
+++ b/cosmos_transfer1/auxiliary/depth_anything/model/depth_anything.py
@@ -34,13 +34,14 @@ class DepthAnythingModel:
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         # Load image processor and model with half precision
         log.info(f"Loading Depth Anything model - {DEPTH_ANYTHING_MODEL_CHECKPOINT}...")
+        checkpoint = os.getenv("CHECKPOINT_DIR", "checkpoints")
         self.image_processor = AutoImageProcessor.from_pretrained(
-            DEPTH_ANYTHING_MODEL_CHECKPOINT,
+            os.path.join(checkpoint, DEPTH_ANYTHING_MODEL_CHECKPOINT),
             torch_dtype=torch.float16,
             trust_remote_code=True,
         )
         self.model = AutoModelForDepthEstimation.from_pretrained(
-            DEPTH_ANYTHING_MODEL_CHECKPOINT,
+            os.path.join(checkpoint, DEPTH_ANYTHING_MODEL_CHECKPOINT),
             torch_dtype=torch.float16,
             trust_remote_code=True,
         ).to(self.device)


### PR DESCRIPTION
When I tried with examples given like:
```
"control_overrides": {"seg": {"input_control": "path/to/video1_seg.mp4"}, "depth": {"input_control": null}}}
```
I got following error:
```
 no input_control provided for depth. generating input control video with DepthAnythingModel
Loading Depth Anything model - depth-anything/Depth-Anything-V2-Small-hf...
OSError: We couldn't connect to 'https://huggingface.co' to load this file, couldn't find it in the cached files and it looks like depth-anything/Depth-Anything-V2-Small-hf is not the path to a directory containing a file named preprocessor_config.json.
```
The correct relative path should be:
```
checkpoints/depth-anything/Depth-Anything-V2-Small-hf
```
if we use script to download all dependencies. The code here forget to make a path join so it does not read from the correct path, which I think has a different behavior from doc.
This is a relative simple fix, please tell me if we have a more elegant way to fix this.
BTW, I think this issue https://github.com/nvidia-cosmos/cosmos-transfer1/issues/79 has the same problem as this one. Maybe we could fix that too.