### PR TITLE
fix: minor update to distillation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Cosmos-Transfer1 includes the following:
 
 ## News
 
-- [2025/08] **Cosmos-Transfer1-7B Edge Distilled** is available! Now you can generate videos in a single diffusion step (vs. 35 steps), significantly speeding up inference. We provide the distillation recipe and training code, so you can even distill your own models! Try it out and tell us what you think!
+- [2025/08] **Cosmos-Transfer1-7B Edge Distilled** is available! Now you can generate videos in a single diffusion step (vs. 36 steps), significantly speeding up inference. We provide the distillation recipe and training code, so you can even distill your own models! Try it out and tell us what you think!
 
   - [Inference guide](examples/inference_cosmos_transfer1_7b.md#example-2-distilled-single-control-edge)
 

--- a/examples/distillation_cosmos_transfer1_7b.md
+++ b/examples/distillation_cosmos_transfer1_7b.md
@@ -1,6 +1,6 @@
 # Distilling Cosmos-Transfer1 Models
 
-In July 2025, we released a distilled version of the Cosmos-Transfer1-7B Edge model. We distilled the original 35-step Cosmos-Transfer1-7B Edge model into a single-step model while preserving output quality.
+We previously released a distilled version of the Cosmos-Transfer1-7B Edge model. While the original model required 72 total inferences (36 steps x 2) due to classifier-free guidance (CFG), the distilled model requires only a single inference without CFG. This achieves a 72x speedup while maintaining output quality.
 
 We now provide our distillation recipe and training code, so that you can replicate the diffusion step distillation process using your own models and data.
 


### PR DESCRIPTION
Minor update to distillation docs

- Update 35-steps --> 36-steps for the teacher model
  - We refer to this as a 36-step model to account for the final `sample_clean` denoising step, though the Cosmos inference API reports it as 35 steps.
  - This change helps keep the distillation details consistent across Cosmos docs.